### PR TITLE
CPU usage change

### DIFF
--- a/src/NotifyWhenMicrosoftOutlookReminderWindowIsOpen.ahk
+++ b/src/NotifyWhenMicrosoftOutlookReminderWindowIsOpen.ahk
@@ -58,15 +58,13 @@ Loop
 	outlookProcessName := (Settings.OutlookProcessName).Value
 	secondsToWaitForWindowToBeClosed := (Settings.SecondsBeforeAlertsAreReTriggeredWhenOutlookRemindersWindowIsStillOpen).Value
 
-	; Wait for a window with the matching Outlook reminders text in it's title to appear.
-	WinWait, %outlookRemindersWindowTitleTextToMatch%,
-
 	; Get the ID of the window if it does indeed belong to the Outlook process.
 	outlookRemindersWindowId := GetOutlookRemindersWindowId(outlookRemindersWindowTitleTextToMatch,outlookProcessName)
 
 	; If the found window doesn't belong to Outlook.exe, keep waiting for the actual Outlook reminders window.
 	if (outlookRemindersWindowId = 0)
 	{
+		Sleep, 10000
 		continue
 	}
 


### PR DESCRIPTION
This is on my computer, so I don't know if anyone else notices or cares, but the script/app would constantly take 1% of my CPU. That doesn't sound like much, but I have well over 100 other processes (499 at this minute, actually) that also want to use CPU and if they each took 1%, the computer wouldn't be usable. In looking at the "CPU time" column in Task Manager, I can see that it rivals my antivirus software for the amount of total CPU it's using. 

See the attached changes. I am not proposing these exact changes get merged in but I figured it was easier to show what I did with a pull request than an Issue... I take out the WinWait and look for the window after a hard-coded (10 seconds) amount of time. Obviously, if we thought this was a good idea, that would be a configurable amount of time. 

After making these changes, the CPU now sits around .03% (as seen in Process Explorer).